### PR TITLE
Corrected package.json syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "one-cerner-style-icons",
-  "version": "1.2.2”,
+  "version": "1.2.2",
   "description": "One Cerner Style Icon Repository",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixed package.json syntax that was breaking npm install in dependent projects.