### PR TITLE
Fixing invalid json in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "one-cerner-style-icons",
-  "version": “1.6.0”,
+  "version": "1.6.0",
   "description": "One Cerner Style Icon Repository",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The recent commit has invalid json in the package.json file. The quotes for the version number are invalid.

This is causing a build error when trying to build project that has `one-cerner-style-icons` as a dependency.